### PR TITLE
Scssphp 1.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ version 3][license] (or any later version).
 
 ## Release notes
 
+### Version 2.0.7
+
+Released on 2021-05-18
+
+* Increased minimum version of `scssphp`
+
 ### Version 2.0.6
 
 Released on 2021-05-15

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
 	},
 	"require": {
 		"php": ">=5.6",
-		"scssphp/scssphp": ">=1.2.1 <1.5"
+		"scssphp/scssphp": "^1.5.2"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
scssphp 1.5.2 reverts the breaking change introduced in 1.5.0 (https://github.com/scssphp/scssphp/pull/406)

In order to not have an overly complicated range (>=1.2.1 <1.5 and >= 1.5.2), is it fine to just set the minimum as 1.5.2 and then  bump SCSS's patch version again? The default Chameleon Bootstrap does compile correctly now.