### PR TITLE
CI: switch the install script to git clone

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
           - mw: 'REL1_45'
             php: 8.3
             experimental: false
-          - mw: 'master'
+          - mw: 'REL1_46'
             php: 8.4
-            experimental: true
+            experimental: false
           - mw: 'master'
             php: 8.5
             experimental: true
@@ -53,7 +53,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v2
 
       - name: Cache Composer cache
         uses: actions/cache@v4
@@ -78,7 +78,14 @@ jobs:
         run: composer update --no-progress --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Run PHPUnit
-        run: php tests/phpunit/phpunit.php -c vendor/mediawiki/scss
+        run: |
+          if [ -f tests/phpunit/phpunit.php ]; then
+            php tests/phpunit/phpunit.php -c vendor/mediawiki/scss
+          else
+            # MW 1.46 and later
+            composer phpunit:config
+            vendor/bin/phpunit vendor/mediawiki/scss/tests/phpunit
+          fi
 
   code-style:
     name: "Code style: MW ${{ matrix.mw }}, PHP ${{ matrix.php }}"
@@ -137,7 +144,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v2
 
       - name: Cache Composer cache
         uses: actions/cache@v4
@@ -198,7 +205,7 @@ jobs:
             mediawiki
             !mediawiki/extensions/
             !mediawiki/vendor/
-          key: mw_${{ matrix.mw }}-php${{ matrix.php }}
+          key: mw_${{ matrix.mw }}-php${{ matrix.php }}-v2
 
       - name: Cache Composer cache
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             experimental: false
           - mw: 'REL1_46'
             php: 8.4
-            experimental: false
+            experimental: true
           - mw: 'master'
             php: 8.5
             experimental: true

--- a/.github/workflows/installWiki.sh
+++ b/.github/workflows/installWiki.sh
@@ -3,10 +3,7 @@
 MW_BRANCH=$1
 EXTENSION_NAME=$2
 
-wget https://github.com/wikimedia/mediawiki/archive/$MW_BRANCH.tar.gz -nv
-
-tar -zxf $MW_BRANCH.tar.gz
-mv mediawiki-$MW_BRANCH mediawiki
+git clone --depth 1 --branch ${MW_BRANCH} https://github.com/wikimedia/mediawiki.git mediawiki
 
 cd mediawiki
 


### PR DESCRIPTION
Originally an install-script bitrot fix; expanded scope to also bring the matrix and PHPUnit invocation in line with Chameleon, Bootstrap, and BootstrapComponents.

## Switch the install script to `git clone`

Wikimedia recently converted older MediaWiki release refs (REL1_39 through REL1_42, plus older extension/skin branches) from branches to tags. The original branch refs still exist for now, so the same names resolve as both a branch AND a tag. GitHub's archive endpoint can no longer disambiguate the bare `archive/<name>.tar.gz` URL form in that state, and returns an HTTP 300 Multiple Choices with a 105-byte body:

> the given path has multiple possibilities: #<Git::Ref:...>, #<Git::Ref:...>

Switching `installWiki.sh` to `git clone --depth 1 --branch <name>` resolves whichever ref form exists and is robust to whatever Wikimedia does with the refs next.

## Add MediaWiki 1.46 and detect the PHPUnit runner

MediaWiki 1.46 removed the `tests/phpunit/phpunit.php` legacy entry point in favour of `vendor/bin/phpunit` with `phpunit.xml` generated by `composer phpunit:config`. Detect which runner is available at the file-existence level instead of pinning on the MediaWiki version, matching the pattern already in use in Chameleon, Bootstrap, and BootstrapComponents.

## Bump the MediaWiki cache key to `-v2`

Existing wget-era cache entries lack `phpunit.xml.template` because they were populated from the archive tarball (the file is `export-ignore`d from `git archive`). Without a cache key bump, on every cache hit after merge the file would be absent and `composer phpunit:config` would fail. Bump to `-v2` so the next run produces a fresh entry from the `git clone` path with the file included. Apply to all three Cache MediaWiki invocations so PHPUnit/PHPStan/Psalm keep sharing a single cache per row.

## Keep REL1_46 experimental until scssphp gets a PHP 8.4 fix

REL1_46 on PHP 8.4 fails one test (`ResourceLoaderSCSSModuleTest::testGetStyles`) because `scssphp/scssphp` v1.x (the line pinned at `^1.13.0`) triggers PHP 8.4's "implicit nullable parameter" deprecation in `Compiler::multiplyMedia()`, which the new PHPUnit runner converts to a test error. This is a real PHP 8.4 compatibility gap in `scssphp` v1.x and is tracked separately by #31 ("Make compatible with scssphp 2.x"). Until that lands, REL1_46 is marked experimental so CI remains useful.